### PR TITLE
fix : facade가 최대한 도메인 상태정보를 갖지 않아 결합도를 낮춘다

### DIFF
--- a/product-service/src/main/java/com/msa/application/ProductFacade.java
+++ b/product-service/src/main/java/com/msa/application/ProductFacade.java
@@ -20,16 +20,16 @@ public class ProductFacade {
 
     @Transactional
     public Long createProduct(Requests.CreateProductRequest request) {
+        // ㄱㅣ존
         Category category = categoryService.findById(request.getCategoryId());
         Product product = productService.createProduct(request.getName(),request.getPrice(),request.getStock());
         productCategoryService.createProductCategory(product, category);
-        //todo send event to order aggregate
+
         return product.getId();
     }
 
     @Transactional
     public void updateProduct(Long productId, Requests.UpdateProductRequest request) {
-        Product originProduct = productService.findById(productId);
-        productService.updateProduct(originProduct, request.getName(), request.getPrice(), request.getStock());
+        productService.updateProduct(productId, request.getName(), request.getPrice(), request.getStock());
     }
 }

--- a/product-service/src/main/java/com/msa/domain/service/ProductService.java
+++ b/product-service/src/main/java/com/msa/domain/service/ProductService.java
@@ -38,7 +38,8 @@ public class ProductService {
     }
 
     @Transactional
-    public void updateProduct(Product originProduct, String name, Integer price, Integer stock) {
+    public void updateProduct(Long productId, String name, Integer price, Integer stock) {
+        Product originProduct = productRepository.findById(productId);
         originProduct.editProductNameInfo(name);
         originProduct.editProductPriceInfo(price);
         originProduct.editProductStockInfo(stock);

--- a/product-service/src/test/java/com/msa/service/product/UpdateProduct.java
+++ b/product-service/src/test/java/com/msa/service/product/UpdateProduct.java
@@ -15,6 +15,8 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @Transactional
 public class UpdateProduct extends ProductBase{
@@ -35,8 +37,9 @@ public class UpdateProduct extends ProductBase{
         //given
         ProductInfo info = createMockProductInfo("originProductName", 100, 100);
         Product product = createMockProduct(info);
+        given(productRepository.findById(any())).willReturn(product);
         //when
-        productService.updateProduct(product, "newName", 1, 1);
+        productService.updateProduct(product.getId(), "newName", 1, 1);
 
         //then
         assertTrue(product.getProductInfo().getName().equals("newName"));
@@ -51,9 +54,10 @@ public class UpdateProduct extends ProductBase{
         //given
         ProductInfo info = createMockProductInfo("originProductName", 100, 100);
         Product product = createMockProduct(info);
+        given(productRepository.findById(any())).willReturn(product);
         //when
         assertThrows(IllegalArgumentException.class, () -> {
-            productService.updateProduct(product, "newName", -1, 1);
+            productService.updateProduct(product.getId(), "newName", -1, 1);
         });
 
     }
@@ -64,9 +68,10 @@ public class UpdateProduct extends ProductBase{
         //given
         ProductInfo info = createMockProductInfo("originProductName", 100, 100);
         Product product = createMockProduct(info);
+        given(productRepository.findById(any())).willReturn(product);
         //when
         assertThrows(IllegalArgumentException.class, () -> {
-            productService.updateProduct(product, "newName", 1, -1);
+            productService.updateProduct(product.getId(), "newName", 1, -1);
         });
     }
 }


### PR DESCRIPTION
facade에서 도메인 정보를 갖지 않도록 개선하여 최대한 도메인 상태정보를 갖지 않아 결합도를 낮춘다

todo : createProduct 또한 동일한 방향으로 개선
- 고려사항 1.  단일 서비스(productService)에서 모든 로직을 구현하면 productService가 다른 도메인 서비스 의존성을 갖게될 수 있다
- 고려사항 2. product 식별자를 반환하게하고 식별자를 넘겨주게되는 경우 facade가 도메인 정보를 갖지 않지만 다른 도메인 서비스에서 또 다른 도메인 서비스 의존성을 갖으며 중복 코드가 발생할 수 있다. 